### PR TITLE
Feature/imenu enhancement

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Syohei YOSHIDA <syohex@gmail.com>
 ;; URL: https://github.com/syohex/emacs-terraform-mode
 ;; Version: 0.06
-;; Package-Requires: ((emacs "24.3") (hcl-mode "0.03"))
+;; Package-Requires: ((emacs "24.3") (hcl-mode "0.03") (dash "2.17.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -151,10 +151,10 @@
    (optional "\"")))
 
 (defun terraform--generate-imenu ()
-  (goto-char (point-min))
   (let ((search-results (make-hash-table :test #'equal))
 	(menu-list '()))
     (save-match-data
+      (goto-char (point-min))
       (while (re-search-forward terraform--block-builtins-with-type-only--resource-type-highlight-regexp
 				nil t)
 	(-if-let* ((key (match-string 1))
@@ -164,7 +164,7 @@
 	    (puthash key (push `(,resource-type . ,location) matches) search-results)
 	  (puthash key `((,resource-type . ,location)) search-results)))
 
-
+      (goto-char (point-min))
       (while (re-search-forward terraform--block-builtins-with-name-only--name-highlight-regexp
 				nil t)
 	(-if-let* ((key (match-string 1))
@@ -174,6 +174,7 @@
 	    (puthash key (push `(,resource-name . ,location) matches) search-results)
 	  (puthash key `((,resource-name . ,location)) search-results)))
 
+      (goto-char (point-min))
       (while (re-search-forward terraform--block-builtins-with-type-and-name--name-highlight-regexp
 				nil t)
 	(-if-let* ((key (match-string 1))


### PR DESCRIPTION
This PR changes out the functionality used to generate the imenu list. 

Quotes are stripped off per #35 
Resources and data are listed a under their respective submenu as `<resource_type>/<resource_name>`
Changed match groups to allow reuse of regexps.