### PR TITLE
Fixed aggresive highlighting

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -103,13 +103,20 @@
 
 (defconst terraform--block-builtins-with-type-and-name--type-highlight-regexp
   (eval `(rx (regexp ,(eval terraform--block-builtins-with-type-and-name--builtin-highlight-regexp))
-	     (group-n 2 (+? (not space)))
+	     (group-n 2 "\"" (+? (not space)) "\"")
 	     (one-or-more space))))
 
 (defconst terraform--block-builtins-with-type-and-name--name-highlight-regexp
   (eval `(rx (regexp ,(eval terraform--block-builtins-with-type-and-name--type-highlight-regexp))
 	     (group-n 3 (+? (not space)))
 	     (or (one-or-more space) "{"))))
+
+(defconst terraform--assignment-statement
+  (rx line-start
+      (zero-or-more space)
+      (group-n 1 (one-or-more any))
+      (zero-or-more space)
+      "="))
 
 (defvar terraform-font-lock-keywords
   `((,terraform--block-builtins-without-name-or-type-regexp 1 font-lock-builtin-face)
@@ -120,6 +127,7 @@
     (,terraform--block-builtins-with-type-and-name--builtin-highlight-regexp 1 font-lock-builtin-face)
     (,terraform--block-builtins-with-type-and-name--type-highlight-regexp 2 terraform--resource-type-face t)
     (,terraform--block-builtins-with-type-and-name--name-highlight-regexp 3 terraform--resource-name-face t)
+    (,terraform--assignment-statement 1 font-lock-variable-name-face t)
     ,@hcl-font-lock-keywords))
 
 (defun terraform-format-buffer ()


### PR DESCRIPTION
This patch fixes the highlighting that improperly highlighted the keyword data when on the left hand side of an assignment statement. 

Fixes #48 