### PR TITLE
fix assignment highlighting issue

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -114,7 +114,7 @@
 (defconst terraform--assignment-statement
   (rx line-start
       (zero-or-more space)
-      (group-n 1 (one-or-more any))
+      (group-n 1 (minimal-match (one-or-more any)))
       (zero-or-more space)
       "="))
 

--- a/test/test-highlighting.el
+++ b/test/test-highlighting.el
@@ -198,10 +198,14 @@ foo=\"var\"
   (with-terraform-temp-buffer
     "
     foo=      \"var\"
+    bar = local.baz == 1
 "
 
     (forward-cursor-on "foo")
-    (should (face-at-cursor-p 'font-lock-variable-name-face)))
+    (should (face-at-cursor-p 'font-lock-variable-name-face))
+
+    (forward-cursor-on "baz")
+    (should-not (face-at-cursor-p 'font-lock-variable-name-face)))
 
   (with-terraform-temp-buffer
     "


### PR DESCRIPTION
Hi

This PR fixes an assignment highlighting issue where a line like

 `foo = bar == 1`

was highlighted from `foo` to `bar =`

All the best

