### PR TITLE
fix: provide correct URL for data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ folds-or-indents.  It is not bound by default, but you can bind it to
 
 ### Access to Terraform resource documentation
 
-Within a `resource` or a `data` block, type `C-c C-h` to open a new
+Within a `resource` or a `data` block, type `C-c C-d C-w` to open a new
 browser tab with the resource or data documentation page.
 
 ## Customize Variables

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -316,7 +316,7 @@ If the point is not at the heading, call
 
 (defvar terraform-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-h") #'terraform-open-doc)
+    (define-key map (kbd "C-c C-d C-w") #'terraform-open-doc)
     (define-key map (kbd "C-c C-f") #'outline-toggle-children)
     map))
 

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -270,10 +270,7 @@
     (goto-char (line-beginning-position))
     (unless (looking-at-p "^resource\\|^data")
       (re-search-backward "^resource\\|^data" nil t))
-    (let (doc-dir)
-      (if (equal (word-at-point) "data")
-          (setq doc-dir "data-sources")
-          (setq doc-dir "resources"))
+    (let ((doc-dir (if (equal (word-at-point) "data") "data-sources" "resources")))
       (forward-symbol 2)
       (terraform--resource-url (thing-at-point 'symbol) doc-dir))))
 

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -252,25 +252,30 @@
       (when (re-search-forward (concat "/\\(.*?\\)/" provider "\\]") nil t)
         (match-string 1)))))
 
-(defun terraform--resource-url (resource)
-  "Return the url containing the documentation for RESOURCE."
+(defun terraform--resource-url (resource doc-dir)
+  "Return the url containing the documentation for RESOURCE using DOC-DIR."
   (let* ((provider (terraform--extract-provider resource))
          (provider-ns (terraform--get-resource-provider-namespace provider))
          (resource-name (terraform--extract-resource resource)))
     (if provider-ns
-        (format "https://registry.terraform.io/providers/%s/%s/latest/docs/resources/%s"
+        (format "https://registry.terraform.io/providers/%s/%s/latest/docs/%s/%s"
                 provider-ns
                 provider
+                doc-dir
                 resource-name)
       (user-error "Can not determine the provider namespace for %s" provider))))
 
 (defun terraform--resource-url-at-point ()
   (save-excursion
     (goto-char (line-beginning-position))
-    (unless (looking-at-p "^resource")
-      (re-search-backward "^resource" nil t))
-    (forward-symbol 2)
-    (terraform--resource-url (thing-at-point 'symbol))))
+    (unless (looking-at-p "^resource\\|^data")
+      (re-search-backward "^resource\\|^data" nil t))
+    (let (doc-dir)
+      (if (equal (thing-at-point 'word) "data")
+          (setq doc-dir "data-sources")
+          (setq doc-dir "resources"))
+      (forward-symbol 2)
+      (terraform--resource-url (thing-at-point 'symbol) doc-dir))))
 
 (defun terraform-open-doc ()
   "Open a browser at the URL documenting the resource at point."

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -271,7 +271,7 @@
     (unless (looking-at-p "^resource\\|^data")
       (re-search-backward "^resource\\|^data" nil t))
     (let (doc-dir)
-      (if (equal (thing-at-point 'word) "data")
+      (if (equal (word-at-point) "data")
           (setq doc-dir "data-sources")
           (setq doc-dir "resources"))
       (forward-symbol 2)

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -112,6 +112,20 @@ resource \"elasticstack_elasticsearch_security_user\" \"filebeat_writer\" {
     (cl-letf (((symbol-function 'terraform--get-resource-provider-namespace) (lambda (prov) "elastic")))
       (should (equal (terraform--resource-url-at-point) "https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/elasticsearch_security_user")))))
 
+(ert-deftest command--open-doc--at-data-resource-def-line ()
+  (with-terraform-temp-buffer
+    "
+data \"aws_subnets\" \"example\" {
+  filter {
+    name   = \"vpc-id\"
+    values = [var.vpc_id]
+  }
+}
+"
+    (forward-cursor-on "subnets")
+    (cl-letf (((symbol-function 'terraform--get-resource-provider-namespace) (lambda (prov) "hashicorp")))
+      (should (equal (terraform--resource-url-at-point) "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets")))))
+
 (ert-deftest command--open-doc--in-body ()
   (with-terraform-temp-buffer
     "


### PR DESCRIPTION
Without this commit, hitting `C-c C-h` on a data source opens the page of the corresponding resource page instead of the page of the data source.

This commit fixes this issue and provides the relevant test case.

Closes: #58
