### PR TITLE
C-c C-u: terraform-kill-doc-url - Kill documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ folds-or-indents.  It is not bound by default, but you can bind it to
 Within a `resource` or a `data` block, type `C-c C-d C-w` to open a new
 browser tab with the resource or data documentation page.
 
+Type `C-c C-d C-c` to kill the URL (i.e. copy it to the clipboard) for the documentation page rather than directly open it in the browser.
+
 ## Customize Variables
 
 #### `terraform-indent-level`(Default: `2`)

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -279,6 +279,13 @@
   (interactive)
   (browse-url (terraform--resource-url-at-point)))
 
+(defun terraform-kill-doc-url ()
+  "Kill the URL documenting the resource at point (i.e. copy it to the clipboard)."
+  (interactive)
+  (let* ((url (substring-no-properties (terraform--resource-url-at-point))))
+    (kill-new url)
+    (message "Copied URL: %s" url)))
+
 (defun terraform--outline-level ()
   "Return the depth to which a statement is nested in the outline.
 
@@ -317,6 +324,7 @@ If the point is not at the heading, call
 (defvar terraform-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-d C-w") #'terraform-open-doc)
+    (define-key map (kbd "C-c C-d C-c") #'terraform-kill-doc-url)
     (define-key map (kbd "C-c C-f") #'outline-toggle-children)
     map))
 


### PR DESCRIPTION
## What?

`C-c C-u`: Kill the URL documenting the resource at point (i.e. copy it to the clipboard).

## Why?

At least for me, opening up a URL in "the browser" will open it up in any of my numerous browser windows on any of my numerous desktops. So I'd rather copy the URL and open a new tab myself.

## Issues

I see in #57 and #58 that  there is some discussion about the choice of key bindings in this package. I'm not that bothered with whatever binding is chosen, but I suggest adopting this PR and then figuring out a key binding scheme that works for both cases.
